### PR TITLE
Fix warts parsing with MPLS information.

### DIFF
--- a/TNT/scamper-tnt-cvs-20180523a/scamper/trace/scamper_trace_json.c
+++ b/TNT/scamper-tnt-cvs-20180523a/scamper/trace/scamper_trace_json.c
@@ -47,7 +47,7 @@ static const char rcsid[] =
 
 static char *hop_tostr(scamper_trace_hop_t *hop)
 {
-  char buf[512], tmp[128];
+  char buf[1024], tmp[128];
   scamper_icmpext_t *ie;
   size_t off = 0;
   uint32_t u32;


### PR DESCRIPTION
For warts with MPLS information (especially MPLS labels), the reading buffer may be too small to accommodate everything.